### PR TITLE
build: improve backend routine when executing the monorepository

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "mono": "concurrently \"pnpm api\" \"pnpm web\"",
     "api": "cd api && air",
     "web": "cd web && pnpm start",
+    "mono-alt": "concurrently \"pnpm api-alt\" \"pnpm web\"",
+    "api-alt": "pnpm api-i && cd api && go run main.go",
     "db-up": "cd api && docker-compose up -d",
     "db-down": "cd api && docker-compose down",
     "hooks": "cd hooks && go run main.go",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hooks-web": "cd hooks && go run main.go web",
     "web-i": "cd web && pnpm i && cd ..",
     "api-i": "cd api && swag init && cd ..",
-    "postinstall": "pnpm web-i && pnpm hooks"
+    "postinstall": "concurrently \"pnpm web-i\" \"pnpm api-i\" && pnpm hooks"
   },
   "dependencies": {
     "concurrently": "^8.2.2"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "hooks-api": "cd hooks && go run main.go api",
     "hooks-web": "cd hooks && go run main.go web",
     "web-i": "cd web && pnpm i && cd ..",
+    "api-i": "cd api && swag init && cd ..",
     "postinstall": "pnpm web-i && pnpm hooks"
   },
   "dependencies": {


### PR DESCRIPTION
- Create an `api-i` alias in `package.json` to generate the backend's swagger docs;
- Add an `api-i` call in the `postinstall` routine in order to automatically generate the backend's swagger docs;
- create the `mono-alt` and `api-alt` commands in `package.json` to serve as alternative executions without using `air` to run the backend;